### PR TITLE
A fix to nuget warning (Effort.EF6 1.3.0 depends on NMemory (>= 1.0.2…

### DIFF
--- a/Main/Build/Effort.EF6.nuspec
+++ b/Main/Build/Effort.EF6.nuspec
@@ -12,8 +12,8 @@
         <description>Effort is basicly an ADO.NET provider that executes all the data operations on a lightweight in-process main memory database instead of a traditional external database. It provides some intuitive helper methods too that make really easy to use this provider with existing ObjectContext or DbContext classes. A simple addition to existing code might be enough to create data driven unit tests that can be run without the presence of the external database.</description>
         <summary>Effort is a powerful tool that enables a convenient way to create unit tests for Entity Framework based applications.</summary>
         <dependencies>
-            <dependency id="NMemory" version="[1.0.2,2.0.0)" />
-			<dependency id="EntityFramework" version="[6.0.0,7.0.0)" />
+            <dependency id="NMemory" version="[1.1.0,2.0.0)" />
+            <dependency id="EntityFramework" version="[6.0.0,7.0.0)" />
         </dependencies>
     </metadata>
     <files>

--- a/Main/Build/Effort.nuspec
+++ b/Main/Build/Effort.nuspec
@@ -12,7 +12,7 @@
         <description>Effort is basicly an ADO.NET provider that executes all the data operations on a lightweight in-process main memory database instead of a traditional external database. It provides some intuitive helper methods too that make really easy to use this provider with existing ObjectContext or DbContext classes. A simple addition to existing code might be enough to create data driven unit tests that can be run without the presence of the external database.</description>
         <summary>Effort is a powerful tool that enables a convenient way to create unit tests for Entity Framework based applications.</summary>
         <dependencies>
-            <dependency id="NMemory" version="[1.0.2,2.0.0)" />
+            <dependency id="NMemory" version="[1.1.0,2.0.0)" />
         </dependencies>
         <frameworkAssemblies>
             <frameworkAssembly assemblyName="System.Data.Entity" targetFramework="" />


### PR DESCRIPTION
When you add Nuget reference to Effort.EF6, you get the following warning:
Effort.EF6 1.3.0 depends on NMemory (>= 1.0.2 && < 2.0.0) but NMemory 1.0.2 was not found. An approximate best match of NMemory 1.1.0 was resolved.
I fixed this by editing nuspec files.
